### PR TITLE
Ensure AI modules skip analysis on missing data

### DIFF
--- a/Business_analysis.py
+++ b/Business_analysis.py
@@ -1,9 +1,19 @@
 import yfinance as yf
 import pandas as pd
 import datetime as dt
-import requests 
+import requests
 import json
 from .fetch_info import safe_get_info
+
+
+def _is_valid(value):
+    """Return True if the value is usable in a prompt."""
+    return value not in (None, "N/A", "None")
+
+
+def _has_valid_data(*values):
+    """Return True if any value is not None and not a string 'N/A' or 'None'."""
+    return any(_is_valid(v) for v in values)
 
 def fetch_business_prompt(ticker):
     
@@ -15,6 +25,8 @@ def fetch_business_prompt(ticker):
     business_summary = tick.get('longBusinessSummary', 'N/A')
     country = tick.get('country', 'N/A')
     employees = tick.get('fullTimeEmployees', 'N/A')
+
+    metrics = [industry, sector, business_summary, country, employees]
 
     # Define relevant title keywords
     relevant_titles = [
@@ -51,18 +63,31 @@ def fetch_business_prompt(ticker):
 
     officers_section = "\n".join(filtered_officers) if filtered_officers else "Key executive information not available."
 
+    if not _has_valid_data(*metrics) and officers_section == "Key executive information not available.":
+        return None
+
+    overview_lines = []
+    if _is_valid(industry):
+        overview_lines.append(f"- Industry: {industry}")
+    if _is_valid(sector):
+        overview_lines.append(f"- Sector: {sector}")
+    if _is_valid(country):
+        overview_lines.append(f"- Country: {country}")
+    if _is_valid(employees):
+        overview_lines.append(f"- Employees: {employees}")
+
+    overview_section = "\n".join(overview_lines)
+    summary_section = (
+        f"Business Summary: {business_summary}\n\n" if _is_valid(business_summary) else ""
+    )
+
     bussiness_prompt = f"""
 You are a finacial analyst tasked with evaluating and explaining {ticker} based on the company’s core business and whether it has a sustainable competitive advantage.
 
-Business Overview: 
-- Industry: {industry}
-- Sector: {sector}
-- Country: {country}
-- Employees: {employees}
+Business Overview:
+{overview_section}
 
-Business Summary: {business_summary}
-
-Key Executives:
+{summary_section}Key Executives:
 {officers_section}
 
 Your task is to analyze the company's business model, its competitive position in the market, and its potential for long-term growth. Consider the following aspects:
@@ -76,23 +101,26 @@ Your task is to analyze the company's business model, its competitive position i
 
     return bussiness_prompt
 
-def get_business_response(ticker) -> str: 
-        
-    try: 
-        # Call Ollama API
-            response = requests.post(
-                "http://localhost:11434/api/generate",
-                json={
-                    "model": "qwen2.5:latest",  # or your favorite model
-                    "prompt": fetch_business_prompt(ticker),
-                    "stream": False,
-                    "num_ctx": 32000  # Adjust context size as needed
+def get_business_response(ticker) -> str:
+    prompt = fetch_business_prompt(ticker)
+    if not prompt:
+        return "Business data not available."
 
-                },
-                timeout=120
-            )
-            summary = response.json().get("response", "").strip()
-            return summary
+    try:
+        # Call Ollama API
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            json={
+                "model": "qwen2.5:latest",  # or your favorite model
+                "prompt": prompt,
+                "stream": False,
+                "num_ctx": 32000  # Adjust context size as needed
+
+            },
+            timeout=120
+        )
+        summary = response.json().get("response", "").strip()
+        return summary
 
     except Exception as e:
         print(f"Error calling Ollama API: {e}")

--- a/analyst_opinion.py
+++ b/analyst_opinion.py
@@ -5,6 +5,16 @@ import requests
 import json
 from .fetch_info import safe_get_info
 
+
+def _is_valid(value):
+    """Return True if the value is usable in a prompt."""
+    return value not in (None, "N/A", "None")
+
+
+def _has_valid_data(*values):
+    """Return True if any provided value is valid."""
+    return any(_is_valid(v) for v in values)
+
 def fetch_opinions_prompt(ticker):
     
     tick = safe_get_info(ticker)
@@ -18,31 +28,67 @@ def fetch_opinions_prompt(ticker):
 
     target_mean = tick.get("targetMeanPrice")
     target_median = tick.get("targetMedianPrice")
+    target_high = tick.get("targetHighPrice")
+    target_low = tick.get("targetLowPrice")
     avg_rating = tick.get("averageAnalystRating")
 
     pe_forward = tick.get("forwardPE")
     peg_ratio = tick.get("trailingPegRatio")
     eps_fwd = tick.get("epsForward")
 
+    metrics = [
+        recommendation, analysts, recommendation_mean,
+        target_mean, target_median, avg_rating,
+        pe_forward, peg_ratio, eps_fwd,
+        target_high, target_low
+    ]
+
+    if not _has_valid_data(*metrics):
+        return None
+
+    rec_lines = []
+    if _is_valid(recommendation):
+        rec_lines.append(f"- Recommendation: {recommendation}")
+    if _is_valid(avg_rating):
+        rec_lines.append(f"- Average Rating: {avg_rating}")
+    if _is_valid(analysts):
+        rec_lines.append(f"- Number of Analysts: {analysts}")
+    if _is_valid(recommendation_mean):
+        rec_lines.append(f"- Recommendation Mean: {recommendation_mean}")
+
+    price_lines = []
+    if _is_valid(target_high):
+        price_lines.append(f"- High: {target_high}")
+    if _is_valid(target_low):
+        price_lines.append(f"- Low: {target_low}")
+    if _is_valid(target_mean):
+        price_lines.append(f"- Mean: {target_mean}")
+    if _is_valid(target_median):
+        price_lines.append(f"- Median: {target_median}")
+
+    val_lines = []
+    if _is_valid(pe_forward):
+        val_lines.append(f"- Forward PE Ratio: {pe_forward}")
+    if _is_valid(peg_ratio):
+        val_lines.append(f"- PEG Ratio: {peg_ratio}")
+    if _is_valid(eps_fwd):
+        val_lines.append(f"- EPS Forward: {eps_fwd}")
+
+    rec_section = "\n".join(rec_lines)
+    price_section = "\n".join(price_lines)
+    val_section = "\n".join(val_lines)
+
     analysts_prompt = f"""
 You are a financial analyst tasked with evaluating the stock recommendations for {ticker} based on analyst opinions.
 
 Analyst Recommendations:
-- Recommendation: {recommendation}
-- Average Rating: {avg_rating}
-- Number of Analysts: {analysts}
-- Recommendation Mean: {recommendation_mean}
+{rec_section}
 
 Target Price Range:
-- High: {tick.get("targetHighPrice")}
-- Low: {tick.get("targetLowPrice")}
-- Mean: {target_mean}
-- Median: {target_median}
+{price_section}
 
 Valuation Metrics:
-- Forward PE Ratio: {pe_forward}
-- PEG Ratio: {peg_ratio}
-- EPS Forward: {eps_fwd}
+{val_section}
 
 Please provide a detailed analysis of the stock's potential based on these recommendations, valuation metrics, and price targets.
 """
@@ -51,23 +97,26 @@ Please provide a detailed analysis of the stock's potential based on these recom
 
     return analysts_prompt
 
-def get_opinions_response(ticker) -> str: 
-        
-    try: 
-        # Call Ollama API
-            response = requests.post(
-                "http://localhost:11434/api/generate",
-                json={
-                    "model": "qwen2.5:latest",  # or your favorite model
-                    "prompt": fetch_opinions_prompt(ticker),
-                    "stream": False,
-                    "num_ctx": 32000  # Adjust context size as needed
+def get_opinions_response(ticker) -> str:
+    prompt = fetch_opinions_prompt(ticker)
+    if not prompt:
+        return "Analyst opinion data not available."
 
-                },
-                timeout=120
-            )
-            summary = response.json().get("response", "").strip()
-            return summary
+    try:
+        # Call Ollama API
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            json={
+                "model": "qwen2.5:latest",  # or your favorite model
+                "prompt": prompt,
+                "stream": False,
+                "num_ctx": 32000  # Adjust context size as needed
+
+            },
+            timeout=120
+        )
+        summary = response.json().get("response", "").strip()
+        return summary
 
     except Exception as e:
         print(f"Error calling Ollama API: {e}")

--- a/fetch_info.py
+++ b/fetch_info.py
@@ -20,6 +20,10 @@ def safe_get_info(ticker_symbol, max_retries=5, delay=1):
             else:
                 raise
         except Exception as e:
+            if "401" in str(e):
+                print(f"[Retry {attempt+1}] HTTP 401 error for {ticker_symbol}, retrying...")
+                time.sleep(delay)
+                continue
             print(f"[Retry {attempt+1}] Unexpected error: {e}, retrying...")
             time.sleep(delay)
 

--- a/health_analysis.py
+++ b/health_analysis.py
@@ -5,6 +5,16 @@ import requests
 import json
 from .fetch_info import safe_get_info
 
+
+def _is_valid(value):
+    """Return True if the value is usable in a prompt."""
+    return value not in (None, "N/A", "None")
+
+
+def _has_valid_data(*values):
+    """Return True if any provided value is valid."""
+    return any(_is_valid(v) for v in values)
+
 def fetch_health_prompt(ticker):
     
     tick = safe_get_info(ticker)
@@ -47,54 +57,115 @@ def fetch_health_prompt(ticker):
     free_cashflow = tick.get("freeCashflow", "N/A")
     operating_cashflow = tick.get("operatingCashflow", "N/A")
 
-    # Ownership - who owns shares 
+    # Ownership - who owns shares
     Insiders = tick.get("heldPercentInsiders", "N/A")
     Institutions = tick.get("heldPercentInstitutions", "N/A")
+
+    metrics = [
+        profit_margin, gross_margin, return_on_assets,
+        earnings_growth, revenue_growth,
+        enterprice_to_revenue, total_debt, debt_to_equity,
+        total_revenue, market_cap, pe_ratio, forward_pe_ratio,
+        price_to_book, current_ratio, quick_ratio,
+        free_cashflow, operating_cashflow, Insiders, Institutions,
+    ]
+
+    if not _has_valid_data(*metrics):
+        return None
+
+    def fmt_line(label, value):
+        return f"- {label}: {value}" if _is_valid(value) else None
+
+    profit_lines = list(filter(None, [
+        fmt_line("Profit Margin", profit_margin),
+        fmt_line("Gross Margin", gross_margin),
+        fmt_line("Return on Assets", return_on_assets),
+    ]))
+
+    growth_lines = list(filter(None, [
+        fmt_line("Earnings Growth", earnings_growth),
+        fmt_line("Revenue Growth", revenue_growth),
+    ]))
+
+    efficiency_lines = list(filter(None, [
+        fmt_line("Enterprise to Revenue Ratio", enterprice_to_revenue),
+    ]))
+
+    debt_lines = list(filter(None, [
+        fmt_line("Total Debt", total_debt),
+        fmt_line("Debt to Equity Ratio", debt_to_equity),
+    ]))
+
+    size_lines = list(filter(None, [
+        fmt_line("Total Revenue", total_revenue),
+        fmt_line("Market Cap", market_cap),
+    ]))
+
+    valuation_lines = list(filter(None, [
+        fmt_line("P/E Ratio", pe_ratio),
+        fmt_line("Forward P/E Ratio", forward_pe_ratio),
+        fmt_line("Price to Book Ratio", price_to_book),
+    ]))
+
+    liquidity_lines = list(filter(None, [
+        fmt_line("Current Ratio", current_ratio),
+        fmt_line("Quick Ratio", quick_ratio),
+    ]))
+
+    cash_lines = list(filter(None, [
+        fmt_line("Free Cash Flow", free_cashflow),
+        fmt_line("Operating Cash Flow", operating_cashflow),
+    ]))
+
+    ownership_lines = list(filter(None, [
+        fmt_line("Insider Holdings", Insiders),
+        fmt_line("Institutional Holdings", Institutions),
+    ]))
+
+    profit_section = "\n".join(profit_lines)
+    growth_section = "\n".join(growth_lines)
+    efficiency_section = "\n".join(efficiency_lines)
+    debt_section = "\n".join(debt_lines)
+    size_section = "\n".join(size_lines)
+    valuation_section = "\n".join(valuation_lines)
+    liquidity_section = "\n".join(liquidity_lines)
+    cash_section = "\n".join(cash_lines)
+    ownership_section = "\n".join(ownership_lines)
 
     health_prompt = f"""
 You are a accountant tasked with evaluating the financial health of {ticker} based on its stock data.
 
 Profitability Metrics:
-- Profit Margin: {profit_margin}
-- Gross Margin: {gross_margin}
-- Return on Assets: {return_on_assets}
+{profit_section}
 
 Growth Metrics:
-- Earnings Growth: {earnings_growth}
-- Revenue Growth: {revenue_growth}
+{growth_section}
 
 Efficiency Metrics:
-- Enterprise to Revenue Ratio: {enterprice_to_revenue}
+{efficiency_section}
 
 Debt Metrics:
-- Total Debt: {total_debt}
-- Debt to Equity Ratio: {debt_to_equity}
+{debt_section}
 
 Size Metrics:
-- Total Revenue: {total_revenue}
-- Market Cap: {market_cap}
+{size_section}
 
 Valuation Metrics:
-- P/E Ratio: {pe_ratio}
-- Forward P/E Ratio: {forward_pe_ratio}
-- Price to Book Ratio: {price_to_book}
+{valuation_section}
 
 Liquidity Metrics:
-- Current Ratio: {current_ratio}
-- Quick Ratio: {quick_ratio}
+{liquidity_section}
 
 Cash Flow Metrics:
-- Free Cash Flow: {free_cashflow}
-- Operating Cash Flow: {operating_cashflow}
+{cash_section}
 
 Ownership Metrics:
-- Insider Holdings: {Insiders}
-- Institutional Holdings: {Institutions}
+{ownership_section}
 
 Based on the metrics given above, provide a detailed and structured analysis of {ticker}'s financial health.
 
 Please highlight:
-1. Key strengths and weaknesses 
+1. Key strengths and weaknesses
 2. Areas of risk or concern (e.g., liquidity, high debt)
 3. Overall outlook (positive/neutral/negative)
     """
@@ -104,23 +175,26 @@ Please highlight:
 
     return health_prompt
 
-def get_health_response(ticker) -> str: 
-        
-    try: 
-        # Call Ollama API
-            response = requests.post(
-                "http://localhost:11434/api/generate",
-                json={
-                    "model": "qwen2.5:latest",  # or your favorite model
-                    "prompt": fetch_health_prompt(ticker),
-                    "stream": False,
-                    "num_ctx": 32000  # Adjust context size as needed
+def get_health_response(ticker) -> str:
+    prompt = fetch_health_prompt(ticker)
+    if not prompt:
+        return "Health data not available."
 
-                },
-                timeout=120
-            )
-            summary = response.json().get("response", "").strip()
-            return summary
+    try:
+        # Call Ollama API
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            json={
+                "model": "qwen2.5:latest",  # or your favorite model
+                "prompt": prompt,
+                "stream": False,
+                "num_ctx": 32000  # Adjust context size as needed
+
+            },
+            timeout=120
+        )
+        summary = response.json().get("response", "").strip()
+        return summary
 
     except Exception as e:
         print(f"Error calling Ollama API: {e}")


### PR DESCRIPTION
## Summary
- add `_is_valid` helper and filter out N/A fields when building prompts
- better 401 handling in `safe_get_info`
- show only available metrics in business, analyst, and health prompts

## Testing
- `python -m py_compile Business_analysis.py analyst_opinion.py health_analysis.py Summary.py fetch_info.py views.py`


------
https://chatgpt.com/codex/tasks/task_e_68545c5608988326819f7cefa8ea5e09